### PR TITLE
Add OPCOM player tasking for defend/reserve orders

### DIFF
--- a/addons/mil_opcom/opcom.fsm
+++ b/addons/mil_opcom/opcom.fsm
@@ -440,11 +440,21 @@ class FSM
                          "                    case (""defend"") : {" \n
                          "                        [_target,""opcom_state"",""defending""] call AliVE_fnc_HashSet;" \n
                          "" \n
+                         "                        if ([_side,[""defending""]] call ALIVE_fnc_OPCOMgetHighestPrioObjective == _targetId) then {" \n
+                         "                            _targets = [_pos, 300, [_enemySide,""entity""],true] call ALIVE_fnc_getNearProfiles;" \n
+                         "                            [_side,_faction,""MilDefence"",_targets,""OPCOM"",true] call ALiVE_fnc_taskRequest;" \n
+                         "                        };" \n
+                         "" \n
                          "                        //Trigger new OPCOM analysis after TACOM confirmation including TACOMs answer" \n
                          "                        _OPCOM_DATA = [""analyze"",nil];" \n
                          "                    };" \n
                          "                    case (""reserve"") : {" \n
                          "                        [_target,""opcom_state"",""reserving""] call AliVE_fnc_HashSet;" \n
+                         "" \n
+                         "                        if ([_side,[""reserving""]] call ALIVE_fnc_OPCOMgetHighestPrioObjective == _targetId) then {" \n
+                         "                            _targets = [_pos, 300, [_enemySide,""entity""],true] call ALIVE_fnc_getNearProfiles;" \n
+                         "                            [_side,_faction,""MilDefence"",_targets,""OPCOM"",true] call ALiVE_fnc_taskRequest;" \n
+                         "                        };" \n
                          "" \n
                          "                        //Trigger new OPCOM analysis after TACOM confirmation including TACOMs answer" \n
                          "                        _OPCOM_DATA = [""analyze"",nil];" \n


### PR DESCRIPTION
### Motivation
- Enable OPCOM to generate structured player tasking for defensive operations so players receive organized orders (similar to existing attack tasking). 

### Description
- Added logic in `addons/mil_opcom/opcom.fsm` so `defend` and `reserve` confirmations will, when the objective is the side's highest-priority objective, gather nearby enemy profiles and call `ALiVE_fnc_taskRequest` with task type `MilDefence` to create C2ISTAR player tasks. 

### Testing
- Ran repository checks and validations: `apply_patch` succeeded and changes were inspected with `git diff -- addons/mil_opcom/opcom.fsm`, `nl -ba addons/mil_opcom/opcom.fsm | sed -n '432,462p'`, `git status --short`, and `git show --stat --oneline HEAD`, all of which completed successfully and the change was committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47fc39ad0833081d0e0f9b04c7320)