### PR TITLE
It now keeps per-settlement, per-side support state

### DIFF
--- a/addons/mil_c2istar/CfgFunctions.hpp
+++ b/addons/mil_c2istar/CfgFunctions.hpp
@@ -231,9 +231,19 @@ class CfgFunctions {
                 file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskApplyPopulationEffect.sqf";
                 RECOMPILE;
             };
+            class taskGetCivilianSupportState {
+                description = "Utility get or create persistent civilian support state for a settlement";
+                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetCivilianSupportState.sqf";
+                RECOMPILE;
+            };
             class taskGetCivilianCluster {
                 description = "Utility get a civilian settlement cluster for Hearts and Minds tasking";
                 file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskGetCivilianCluster.sqf";
+                RECOMPILE;
+            };
+            class taskUpdateCivilianSupportState {
+                description = "Utility update persistent civilian support state for Hearts and Minds tasks";
+                file = "\x\alive\addons\mil_C2ISTAR\utils\fnc_taskUpdateCivilianSupportState.sqf";
                 RECOMPILE;
             };
             class taskGetInsurgencyLocation {

--- a/addons/mil_c2istar/tasks/fnc_taskAidDelivery.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskAidDelivery.sqf
@@ -61,7 +61,13 @@ switch (_taskState) do {
         if (_clusterData isEqualTo []) exitWith {["C2ISTAR - Task AidDelivery - No civilian settlement found!"] call ALiVE_fnc_Dump};
 
         private _cluster = _clusterData select 0;
+        private _supportState = [_clusterData, 2, []] call BIS_fnc_param;
         private _clusterCenter = [_cluster, "center", []] call ALIVE_fnc_hashGet;
+        private _clusterID = [_cluster, "clusterID", ""] call ALIVE_fnc_hashGet;
+        private _supportPhase = "Stabilize";
+        if !(_supportState isEqualTo []) then {
+            _supportPhase = [_supportState, "phase", "Stabilize"] call ALIVE_fnc_hashGet;
+        };
         if (_clusterCenter isEqualTo []) exitWith {["C2ISTAR - Task AidDelivery - Invalid civilian cluster center!"] call ALiVE_fnc_Dump};
 
         private _contactPosition = [_clusterCenter, 5, 30, 3, 0, 0.25, 0] call BIS_fnc_findSafePos;
@@ -184,6 +190,10 @@ switch (_taskState) do {
         [_taskParams, "cleanup", [_contact, _aidCrate]] call ALIVE_fnc_hashSet;
         [_taskParams, "completionVar", _completionVar] call ALIVE_fnc_hashSet;
         [_taskParams, "supportValue", 8] call ALIVE_fnc_hashSet;
+        [_taskParams, "clusterID", _clusterID] call ALIVE_fnc_hashSet;
+        [_taskParams, "supportPhase", _supportPhase] call ALIVE_fnc_hashSet;
+        [_taskParams, "taskType", "AidDelivery"] call ALIVE_fnc_hashSet;
+        [_taskParams, "cooldownDuration", 1800] call ALIVE_fnc_hashSet;
         [_taskParams, "lastState", ""] call ALIVE_fnc_hashSet;
 
         _result = [_tasks, _taskParams];
@@ -276,7 +286,16 @@ switch (_taskState) do {
                 ["chat_success", _currentTaskDialog, _taskSide, _taskPlayers] call ALIVE_fnc_taskCreateRadioBroadcastForPlayers;
                 [_currentTaskDialog, _taskSide, _taskFaction] call ALIVE_fnc_taskCreateReward;
 
-                [_taskPosition, _taskSide, [_params, "supportValue", 8] call ALIVE_fnc_hashGet] call ALIVE_fnc_taskApplyPopulationEffect;
+                [
+                    _taskPosition,
+                    _taskSide,
+                    [_params, "supportValue", 8] call ALIVE_fnc_hashGet,
+                    [
+                        [_params, "clusterID", ""] call ALIVE_fnc_hashGet,
+                        [_params, "taskType", "AidDelivery"] call ALIVE_fnc_hashGet,
+                        [_params, "cooldownDuration", 1800] call ALIVE_fnc_hashGet
+                    ]
+                ] call ALIVE_fnc_taskApplyPopulationEffect;
 
                 [_params] call _cleanupObjects;
             };

--- a/addons/mil_c2istar/tasks/fnc_taskMeetLocalLeader.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskMeetLocalLeader.sqf
@@ -61,7 +61,13 @@ switch (_taskState) do {
         if (_clusterData isEqualTo []) exitWith {["C2ISTAR - Task MeetLocalLeader - No civilian settlement found!"] call ALiVE_fnc_Dump};
 
         private _cluster = _clusterData select 0;
+        private _supportState = [_clusterData, 2, []] call BIS_fnc_param;
         private _clusterCenter = [_cluster, "center", []] call ALIVE_fnc_hashGet;
+        private _clusterID = [_cluster, "clusterID", ""] call ALIVE_fnc_hashGet;
+        private _supportPhase = "Stabilize";
+        if !(_supportState isEqualTo []) then {
+            _supportPhase = [_supportState, "phase", "Stabilize"] call ALIVE_fnc_hashGet;
+        };
         if (_clusterCenter isEqualTo []) exitWith {["C2ISTAR - Task MeetLocalLeader - Invalid civilian cluster center!"] call ALiVE_fnc_Dump};
 
         private _leaderPosition = [_clusterCenter, 5, 25, 2, 0, 0.25, 0] call BIS_fnc_findSafePos;
@@ -162,6 +168,10 @@ switch (_taskState) do {
         [_taskParams, "cleanup", [_leader]] call ALIVE_fnc_hashSet;
         [_taskParams, "completionVar", _completionVar] call ALIVE_fnc_hashSet;
         [_taskParams, "supportValue", 10] call ALIVE_fnc_hashSet;
+        [_taskParams, "clusterID", _clusterID] call ALIVE_fnc_hashSet;
+        [_taskParams, "supportPhase", _supportPhase] call ALIVE_fnc_hashSet;
+        [_taskParams, "taskType", "MeetLocalLeader"] call ALIVE_fnc_hashSet;
+        [_taskParams, "cooldownDuration", 2700] call ALIVE_fnc_hashSet;
         [_taskParams, "lastState", ""] call ALIVE_fnc_hashSet;
 
         _result = [_tasks, _taskParams];
@@ -219,7 +229,16 @@ switch (_taskState) do {
                 ["chat_success", _currentTaskDialog, _taskSide, _taskPlayers] call ALIVE_fnc_taskCreateRadioBroadcastForPlayers;
                 [_currentTaskDialog, _taskSide, _taskFaction] call ALIVE_fnc_taskCreateReward;
 
-                [_taskPosition, _taskSide, [_params, "supportValue", 10] call ALIVE_fnc_hashGet] call ALIVE_fnc_taskApplyPopulationEffect;
+                [
+                    _taskPosition,
+                    _taskSide,
+                    [_params, "supportValue", 10] call ALIVE_fnc_hashGet,
+                    [
+                        [_params, "clusterID", ""] call ALIVE_fnc_hashGet,
+                        [_params, "taskType", "MeetLocalLeader"] call ALIVE_fnc_hashGet,
+                        [_params, "cooldownDuration", 2700] call ALIVE_fnc_hashGet
+                    ]
+                ] call ALIVE_fnc_taskApplyPopulationEffect;
 
                 [_params] call _cleanupObjects;
             };

--- a/addons/mil_c2istar/tasks/fnc_taskRepairCriticalService.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskRepairCriticalService.sqf
@@ -51,7 +51,13 @@ switch (_taskState) do {
         if (_clusterData isEqualTo []) exitWith {["C2ISTAR - Task RepairCriticalService - No civilian settlement found!"] call ALiVE_fnc_Dump};
 
         private _cluster = _clusterData select 0;
+        private _supportState = [_clusterData, 2, []] call BIS_fnc_param;
         private _clusterCenter = [_cluster, "center", []] call ALIVE_fnc_hashGet;
+        private _clusterID = [_cluster, "clusterID", ""] call ALIVE_fnc_hashGet;
+        private _supportPhase = "Stabilize";
+        if !(_supportState isEqualTo []) then {
+            _supportPhase = [_supportState, "phase", "Stabilize"] call ALIVE_fnc_hashGet;
+        };
         if (_clusterCenter isEqualTo []) exitWith {["C2ISTAR - Task RepairCriticalService - Invalid civilian cluster center!"] call ALiVE_fnc_Dump};
 
         private _nodes = [_cluster, "nodes", []] call ALIVE_fnc_hashGet;
@@ -176,6 +182,10 @@ switch (_taskState) do {
         [_taskParams, "targets", [_targetBuilding]] call ALIVE_fnc_hashSet;
         [_taskParams, "completionVar", _completionVar] call ALIVE_fnc_hashSet;
         [_taskParams, "supportValue", 12] call ALIVE_fnc_hashSet;
+        [_taskParams, "clusterID", _clusterID] call ALIVE_fnc_hashSet;
+        [_taskParams, "supportPhase", _supportPhase] call ALIVE_fnc_hashSet;
+        [_taskParams, "taskType", "RepairCriticalService"] call ALIVE_fnc_hashSet;
+        [_taskParams, "cooldownDuration", 3600] call ALIVE_fnc_hashSet;
         [_taskParams, "lastState", ""] call ALIVE_fnc_hashSet;
 
         _result = [_tasks, _taskParams];
@@ -231,7 +241,16 @@ switch (_taskState) do {
                 ["chat_success", _currentTaskDialog, _taskSide, _taskPlayers] call ALIVE_fnc_taskCreateRadioBroadcastForPlayers;
                 [_currentTaskDialog, _taskSide, _taskFaction] call ALIVE_fnc_taskCreateReward;
 
-                [_taskPosition, _taskSide, [_params, "supportValue", 12] call ALIVE_fnc_hashGet] call ALIVE_fnc_taskApplyPopulationEffect;
+                [
+                    _taskPosition,
+                    _taskSide,
+                    [_params, "supportValue", 12] call ALIVE_fnc_hashGet,
+                    [
+                        [_params, "clusterID", ""] call ALIVE_fnc_hashGet,
+                        [_params, "taskType", "RepairCriticalService"] call ALIVE_fnc_hashGet,
+                        [_params, "cooldownDuration", 3600] call ALIVE_fnc_hashGet
+                    ]
+                ] call ALIVE_fnc_taskApplyPopulationEffect;
             };
         };
     };

--- a/addons/mil_c2istar/utils/fnc_taskApplyPopulationEffect.sqf
+++ b/addons/mil_c2istar/utils/fnc_taskApplyPopulationEffect.sqf
@@ -24,8 +24,9 @@ OpenAI
 
 params [
     ["_position", [], [[]]],
-    ["_taskSide", "", [""]],
-    ["_value", 0, [0]]
+    ["_taskSide", ""],
+    ["_value", 0, [0]],
+    ["_supportData", [], [[]]]
 ];
 
 if (_position isEqualTo [] || {_value <= 0}) exitWith {false};
@@ -49,5 +50,52 @@ private _otherSides = ["EAST", "WEST", "GUER"] - [_sideText];
 
 [_position, [_sideText], _value * -1] call ALIVE_fnc_updateSectorHostility;
 [_position, _otherSides, _value] call ALIVE_fnc_updateSectorHostility;
+
+if !(_supportData isEqualTo []) then {
+    _supportData params [
+        ["_clusterID", "", [""]],
+        ["_taskType", "", [""]],
+        ["_cooldownDuration", 0, [0]]
+    ];
+
+    private _cluster = nil;
+
+    if (!isNil "ALIVE_clusterHandler" && {!(_clusterID isEqualTo "")}) then {
+        _cluster = [ALIVE_clusterHandler, "getCluster", _clusterID] call ALIVE_fnc_clusterHandler;
+    };
+
+    if (
+        isNil "_cluster" &&
+        {!isNil "ALIVE_clustersCivSettlement"} &&
+        {!isNil "ALIVE_clusterHandler"}
+    ) then {
+        private _closestDistance = 1000000;
+
+        {
+            private _candidateCluster = [ALIVE_clusterHandler, "getCluster", _x] call ALIVE_fnc_clusterHandler;
+
+            if !(isNil "_candidateCluster") then {
+                private _center = [_candidateCluster, "center", []] call ALIVE_fnc_hashGet;
+
+                if !(_center isEqualTo []) then {
+                    private _distance = _position distance2D _center;
+
+                    if (_distance < _closestDistance) then {
+                        _closestDistance = _distance;
+                        _cluster = _candidateCluster;
+                    };
+                };
+            };
+        } forEach (ALIVE_clustersCivSettlement select 1);
+
+        if (_closestDistance > 1000) then {
+            _cluster = nil;
+        };
+    };
+
+    if !(isNil "_cluster") then {
+        [_cluster, _sideText, _taskType, _value, _cooldownDuration] call ALIVE_fnc_taskUpdateCivilianSupportState;
+    };
+};
 
 true

--- a/addons/mil_c2istar/utils/fnc_taskGetCivilianCluster.sqf
+++ b/addons/mil_c2istar/utils/fnc_taskGetCivilianCluster.sqf
@@ -10,7 +10,7 @@ Select a civilian settlement cluster for Hearts and Minds tasking.
 Parameters:
 
 Returns:
-Array - [cluster, hostility]
+Array - [cluster, hostility, supportState, isOnCooldown]
 
 Examples:
 (begin example)
@@ -26,7 +26,7 @@ OpenAI
 params [
     ["_taskLocation", [], [[]]],
     ["_taskLocationType", "Short", [""]],
-    ["_taskSide", "", [""]],
+    ["_taskSide", ""],
     ["_minHostility", -100000, [0]],
     ["_maxHostility", 100000, [0]],
     ["_taskFaction", "", [""]],
@@ -75,7 +75,14 @@ private _clusterIDs = ALIVE_clustersCivSettlement select 1;
             if (!_isDuplicate) then {
                 private _hostilityHash = [_cluster, "hostility", []] call ALIVE_fnc_hashGet;
                 private _hostility = [_hostilityHash, _sideText, 0] call ALIVE_fnc_hashGet;
-                private _entry = [_cluster, _hostility];
+                private _supportState = [_cluster, _sideText] call ALIVE_fnc_taskGetCivilianSupportState;
+                private _isOnCooldown = false;
+
+                if !(_supportState isEqualTo []) then {
+                    _isOnCooldown = [_supportState, "cooldownUntil", 0] call ALIVE_fnc_hashGet > serverTime;
+                };
+
+                private _entry = [_cluster, _hostility, _supportState, _isOnCooldown];
 
                 _eligibleClusters pushBack _entry;
 
@@ -87,7 +94,14 @@ private _clusterIDs = ALIVE_clustersCivSettlement select 1;
     };
 } forEach _clusterIDs;
 
-private _candidates = if (count _preferredClusters > 0) then {_preferredClusters} else {_eligibleClusters};
+private _preferredClustersAvailable = _preferredClusters select {!(_x select 3)};
+private _eligibleClustersAvailable = _eligibleClusters select {!(_x select 3)};
+private _candidates = switch (true) do {
+    case (count _preferredClustersAvailable > 0): {_preferredClustersAvailable};
+    case (count _preferredClusters > 0): {_preferredClusters};
+    case (count _eligibleClustersAvailable > 0): {_eligibleClustersAvailable};
+    default {_eligibleClusters};
+};
 if (_candidates isEqualTo []) exitWith {[]};
 
 private _sortedClusters = [_candidates, [_taskLocation], {

--- a/addons/mil_c2istar/utils/fnc_taskGetCivilianSupportState.sqf
+++ b/addons/mil_c2istar/utils/fnc_taskGetCivilianSupportState.sqf
@@ -1,0 +1,85 @@
+#include "\x\alive\addons\mil_C2ISTAR\script_component.hpp"
+SCRIPT(taskGetCivilianSupportState);
+
+/* ----------------------------------------------------------------------------
+Function: ALIVE_fnc_taskGetCivilianSupportState
+
+Description:
+Get or create persistent Hearts and Minds support state for a civilian cluster.
+
+Parameters:
+
+Returns:
+Array - Support state hash
+
+Examples:
+(begin example)
+private _state = [_cluster, "WEST"] call ALIVE_fnc_taskGetCivilianSupportState;
+(end)
+
+See Also:
+
+Author:
+OpenAI
+---------------------------------------------------------------------------- */
+
+params [
+    ["_cluster", [], [[]]],
+    ["_taskSide", ""]
+];
+
+if (_cluster isEqualTo []) exitWith {[]};
+
+private _sideText = switch (typeName _taskSide) do {
+    case "SIDE": {
+        private _sideNumber = [_taskSide] call ALIVE_fnc_sideObjectToNumber;
+        [_sideNumber] call ALIVE_fnc_sideNumberToText;
+    };
+    case "STRING": {
+        toUpper _taskSide
+    };
+    default {
+        ""
+    };
+};
+
+if !(_sideText in ["EAST", "WEST", "GUER"]) exitWith {[]};
+
+private _heartsAndMinds = if ("heartsAndMinds" in (_cluster select 1)) then {
+    [_cluster, "heartsAndMinds"] call ALIVE_fnc_hashGet
+} else {
+    private _newHeartsAndMinds = [] call ALIVE_fnc_hashCreate;
+    [_cluster, "heartsAndMinds", _newHeartsAndMinds] call ALIVE_fnc_hashSet;
+    _newHeartsAndMinds
+};
+
+private _supportState = if (_sideText in (_heartsAndMinds select 1)) then {
+    [_heartsAndMinds, _sideText] call ALIVE_fnc_hashGet
+} else {
+    private _newSupportState = [] call ALIVE_fnc_hashCreate;
+    [_newSupportState, "support", 0] call ALIVE_fnc_hashSet;
+    [_newSupportState, "phase", "Stabilize"] call ALIVE_fnc_hashSet;
+    [_newSupportState, "lastTaskType", ""] call ALIVE_fnc_hashSet;
+    [_newSupportState, "lastTaskAt", -1] call ALIVE_fnc_hashSet;
+    [_newSupportState, "cooldownUntil", 0] call ALIVE_fnc_hashSet;
+    [_newSupportState, "successStreak", 0] call ALIVE_fnc_hashSet;
+    [_newSupportState, "failureStreak", 0] call ALIVE_fnc_hashSet;
+    [_heartsAndMinds, _sideText, _newSupportState] call ALIVE_fnc_hashSet;
+    _newSupportState
+};
+
+private _hostilityHash = [_cluster, "hostility", []] call ALIVE_fnc_hashGet;
+private _hostility = [_hostilityHash, _sideText, 0] call ALIVE_fnc_hashGet;
+private _phase = "Stabilize";
+
+if (_hostility <= 25) then {
+    _phase = "Build";
+} else {
+    if (_hostility <= 65) then {
+        _phase = "Engage";
+    };
+};
+
+[_supportState, "phase", _phase] call ALIVE_fnc_hashSet;
+
+_supportState

--- a/addons/mil_c2istar/utils/fnc_taskUpdateCivilianSupportState.sqf
+++ b/addons/mil_c2istar/utils/fnc_taskUpdateCivilianSupportState.sqf
@@ -1,0 +1,49 @@
+#include "\x\alive\addons\mil_C2ISTAR\script_component.hpp"
+SCRIPT(taskUpdateCivilianSupportState);
+
+/* ----------------------------------------------------------------------------
+Function: ALIVE_fnc_taskUpdateCivilianSupportState
+
+Description:
+Update persistent Hearts and Minds support state for a civilian cluster.
+
+Parameters:
+
+Returns:
+Boolean
+
+Examples:
+(begin example)
+[_cluster, "WEST", "AidDelivery", 8, 1800] call ALIVE_fnc_taskUpdateCivilianSupportState;
+(end)
+
+See Also:
+
+Author:
+OpenAI
+---------------------------------------------------------------------------- */
+
+params [
+    ["_cluster", [], [[]]],
+    ["_taskSide", ""],
+    ["_taskType", "", [""]],
+    ["_supportValue", 0, [0]],
+    ["_cooldownDuration", 0, [0]]
+];
+
+if (_cluster isEqualTo []) exitWith {false};
+
+private _supportState = [_cluster, _taskSide] call ALIVE_fnc_taskGetCivilianSupportState;
+if (_supportState isEqualTo []) exitWith {false};
+
+private _support = [_supportState, "support", 0] call ALIVE_fnc_hashGet;
+_support = ((_support + _supportValue) max 0) min 100;
+
+[_supportState, "support", _support] call ALIVE_fnc_hashSet;
+[_supportState, "lastTaskType", _taskType] call ALIVE_fnc_hashSet;
+[_supportState, "lastTaskAt", serverTime] call ALIVE_fnc_hashSet;
+[_supportState, "cooldownUntil", serverTime + (_cooldownDuration max 0)] call ALIVE_fnc_hashSet;
+[_supportState, "successStreak", ([_supportState, "successStreak", 0] call ALIVE_fnc_hashGet) + 1] call ALIVE_fnc_hashSet;
+[_supportState, "failureStreak", 0] call ALIVE_fnc_hashSet;
+
+true


### PR DESCRIPTION
It now keeps per-settlement, per-side support state in fnc_taskGetCivilianSupportState.sqf and fnc_taskUpdateCivilianSupportState.sqf, registered in CfgFunctions.hpp and CfgFunctions.hpp. That state tracks support, phase, lastTaskType, lastTaskAt, cooldownUntil, and streak values.
Task selection now prefers civilian clusters that are not on cooldown in fnc_taskGetCivilianCluster.sqf, and successful H&M tasks push their cluster metadata back through fnc_taskApplyPopulationEffect.sqf. The three MVP tasks now write cooldowns and cluster IDs into their task params in fnc_taskAidDelivery.sqf, fnc_taskMeetLocalLeader.sqf, and fnc_taskRepairCriticalService.sqf. Current cooldowns are 30 minutes, 45 minutes, and 60 minutes respectively.
