### PR TITLE
replaced the broken talk hold-action icon path 

### DIFF
--- a/addons/mil_c2istar/tasks/fnc_taskInformantExfiltration.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskInformantExfiltration.sqf
@@ -259,8 +259,8 @@ switch (_taskState) do {
         [
             _vip,
             "Secure Informant",
-            "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_talk_ca.paa",
-            "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_talk_ca.paa",
+            "\a3\missions_f_oldman\data\img\holdactions\holdAction_talk_ca.paa",
+            "\a3\missions_f_oldman\data\img\holdactions\holdAction_talk_ca.paa",
             "_this distance2D _target < 3 && !(_target getVariable ['ALIVE_Task_VIPPicked', false])",
             "_caller distance2D _target < 3",
             {},

--- a/addons/mil_c2istar/tasks/fnc_taskMeetLocalLeader.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskMeetLocalLeader.sqf
@@ -98,8 +98,8 @@ switch (_taskState) do {
         [
             _leader,
             "Hold Shura",
-            "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_talk_ca.paa",
-            "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_talk_ca.paa",
+            "\a3\missions_f_oldman\data\img\holdactions\holdAction_talk_ca.paa",
+            "\a3\missions_f_oldman\data\img\holdactions\holdAction_talk_ca.paa",
             format ["_this distance2D _target < 3 && !(_target getVariable ['%1', false])", _completionVar],
             "_caller distance2D _target < 3",
             {},

--- a/addons/mil_c2istar/tasks/fnc_taskVIPEscort.sqf
+++ b/addons/mil_c2istar/tasks/fnc_taskVIPEscort.sqf
@@ -261,8 +261,8 @@ switch (_taskState) do {
         [
             _vip,
             "Secure VIP",
-            "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_talk_ca.paa",
-            "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_talk_ca.paa",
+            "\a3\missions_f_oldman\data\img\holdactions\holdAction_talk_ca.paa",
+            "\a3\missions_f_oldman\data\img\holdactions\holdAction_talk_ca.paa",
             "_this distance2D _target < 3 && !(_target getVariable ['ALIVE_Task_VIPPicked', false])",
             "_caller distance2D _target < 3",
             {},


### PR DESCRIPTION
I replaced the broken talk hold-action icon path with the valid Old Man asset path in the three affected task scripts. The new path is \a3\missions_f_oldman\data\img\holdactions\holdAction_talk_ca.paa.