### PR TITLE
Changed the editor-facing naming 

### DIFF
--- a/addons/civ_placement_custom/README.txt
+++ b/addons/civ_placement_custom/README.txt
@@ -14,7 +14,6 @@ ALiVE_civ_placement_custom
 | Rough component description |
 #=============================#
 
-Custom civilian placement for unindexed maps. Mirrors the civilian placement
-force-generation flow while letting mission makers hand-place the objective.
-
-
+Custom military placement at civilian objectives for unindexed maps. Mirrors the
+Military Placement (Civ. Obj.) force-generation flow while letting mission makers
+hand-place the civilian objective.

--- a/addons/civ_placement_custom/stringtable.xml
+++ b/addons/civ_placement_custom/stringtable.xml
@@ -3,13 +3,13 @@
 <Package name="ALiVE">
 <Container name="STR_DN">
 <Key ID="STR_ALIVE_CPC">
-    <English>Civilian Placement (Cust. Obj.)</English>
+    <English>Military Placement (Cust. Civ. Obj.)</English>
 </Key>
 <Key ID="STR_ALIVE_CPC_COMMENT">
-    <English>Custom Civilian Objective</English>
+    <English>Strategic Military Placement at Custom Civilian Objective</English>
 </Key>
 <Key ID="STR_ALIVE_CPC_USAGE">
-    <English>Place the Custom Civilian Objective module in the editor, set the objective radius and priority, then configure the civilian-placement force settings for that location.</English>
+    <English>Place the module in the editor, set the custom civilian objective radius and priority, then configure the military-placement force settings for that civilian objective.</English>
 </Key>
 <Key ID="STR_ALIVE_CPC_OBJECTIVE_SIZE">
     <English>Objective size:</English>


### PR DESCRIPTION
Changed the editor-facing naming so the module reads like the custom counterpart to Military Placement (Civ. Obj.), which matches the actual task.

Civilian Placement (Cust. Obj.) -> Military Placement (Cust. Civ. Obj.)

Description/usage now say this is strategic military placement at a custom civilian objective, not civilian population placement
