### PR TITLE
stopped shadowing _type inside the synced-module loop

### DIFF
--- a/addons/mil_opcom/fnc_INS_helpers.sqf
+++ b/addons/mil_opcom/fnc_INS_helpers.sqf
@@ -516,8 +516,10 @@ ALiVE_fnc_INS_factory = {
                 _allSides = ["EAST","WEST","GUER"];
                 _objective = [[],"getobjectivebyid",_id] call ALiVE_fnc_OPCOM;
 
-                // Convert to data that can be persistet
-                _factory = [[],"convertObject",_factory] call ALiVE_fnc_OPCOM;
+                // Startup can hand us either a persisted [pos, class] ref or the live building object.
+                if !(_factory isEqualType objNull) then {
+                    _factory = [[],"convertObject",_factory] call ALiVE_fnc_OPCOM;
+                };
 
                 // Convert CQB modules
                 {_CQB set [_foreachIndex,[[],"convertObject",_x] call ALiVE_fnc_OPCOM]} foreach _CQB;
@@ -904,8 +906,10 @@ ALiVE_fnc_INS_depot = {
                 // Store center position
                 _center = _pos;
 
-                // Convert to data that can be persistet
-                _depot = [[],"convertObject",_depot] call ALiVE_fnc_OPCOM;
+                // Startup can hand us either a persisted [pos, class] ref or the live building object.
+                if !(_depot isEqualType objNull) then {
+                    _depot = [[],"convertObject",_depot] call ALiVE_fnc_OPCOM;
+                };
 
                 // Convert CQB modules
                 {_CQB set [_foreachIndex,[[],"convertObject",_x] call ALiVE_fnc_OPCOM]} foreach _CQB;
@@ -983,8 +987,10 @@ ALiVE_fnc_INS_recruit = {
                 // Store center position
                 _center = _pos;
 
-                // Convert to data that can be persistet
-                _HQ = [[],"convertObject",_HQ] call ALiVE_fnc_OPCOM;
+                // Startup can hand us either a persisted [pos, class] ref or the live building object.
+                if !(_HQ isEqualType objNull) then {
+                    _HQ = [[],"convertObject",_HQ] call ALiVE_fnc_OPCOM;
+                };
 
                 // Convert CQB modules
                 {_CQB set [_foreachIndex,[[],"convertObject",_x] call ALiVE_fnc_OPCOM]} foreach _CQB;

--- a/addons/mil_opcom/fnc_OPCOM.sqf
+++ b/addons/mil_opcom/fnc_OPCOM.sqf
@@ -362,7 +362,7 @@ switch(_operation) do {
 
                         //Iterate through all synchronized modules
                         for "_i" from 0 to ((count synchronizedObjects _logic)-1) do {
-                            private ["_obj","_mod","_size","_type","_priority"];
+                            private ["_obj","_mod","_size","_objectiveType","_priority"];
 
                             _mod = (synchronizedObjects _logic) select _i;
 
@@ -394,13 +394,13 @@ switch(_operation) do {
                                     _priority = _mod getvariable ["priority",200];
 
                                     //Get type of location-logic from config
-                                    _type = getText(configfile >> "CfgVehicles" >> (typeOf _mod) >> "displayName");
+                                    _objectiveType = getText(configfile >> "CfgVehicles" >> (typeOf _mod) >> "displayName");
 
                                     //Create #Hash objective for this location
                                     _obj = [nil, "createhashobject"] call ALIVE_fnc_OPCOM;
                                     [_obj,"center",getposATL _mod] call ALiVE_fnc_HashSet;
                                     [_obj,"size",_size] call ALiVE_fnc_hashSet;
-                                    [_obj,"objectiveType",_type] call ALiVE_fnc_hashSet;
+                                    [_obj,"objectiveType",_objectiveType] call ALiVE_fnc_hashSet;
                                     [_obj,"priority",_priority] call ALiVE_fnc_hashSet;
                                     [_obj,"clusterID",""] call ALiVE_fnc_hashSet;
 


### PR DESCRIPTION
so the asymmetric check at line 374 now reads the actual OPCOM control type instead of an uninitialized local. The factory/depot/HQ helpers now accept either a persisted [pos, class] ref or a live object, which prevents the object-to-array regression that was killing the spawn and hold-action setup.